### PR TITLE
Fix case of buffer underflow while trying to build ASN1 object from c…

### DIFF
--- a/Sources/ASN1/ASN1.swift
+++ b/Sources/ASN1/ASN1.swift
@@ -309,8 +309,10 @@ public class ASN1: Equatable {
         if tagClass == 2 {
             if length == INDEFINITE {
                 return try ASN1Ctx(tag, indefiniteLength(input))
+            } else if constructed {
+                return try ASN1Ctx(tag, length > 0 ? [ASN1.build(input.nextBytes(length))] : [])
             } else {
-                return try constructed ? ASN1Ctx(tag, [ASN1.build(input.nextBytes(length))]) : ASN1Ctx(tag, input.nextBytes(length))
+                return try ASN1Ctx(tag, input.nextBytes(length))
             }
         } else if tagClass == 0 {
             if length == INDEFINITE && tag != TAG_Sequence && tag != TAG_Set {


### PR DESCRIPTION
This fixes an issue where attempting to read a **context-specific** tag that is **constructed** but has **length zero** causes a erroneous read of the zero-length buffer (in `ASN1.doBuild: let nb = try input.nextByte()`)

This was encountered in a _Keychain Access_-generated x509 `certificate-signing-request`:

```
    0:d=0  hl=4 l= 647 cons: SEQUENCE
    4:d=1  hl=4 l= 367 cons: SEQUENCE
    8:d=2  hl=2 l=   1 prim: INTEGER           :00
   11:d=2  hl=2 l=  66 cons: SEQUENCE
   13:d=3  hl=2 l=  31 cons: SET
   15:d=4  hl=2 l=  29 cons: SEQUENCE
   17:d=5  hl=2 l=   9 prim: OBJECT            :emailAddress
   28:d=5  hl=2 l=  16 prim: IA5STRING         :user@example.com
   46:d=3  hl=2 l=  18 cons: SET
   48:d=4  hl=2 l=  16 cons: SEQUENCE
   50:d=5  hl=2 l=   3 prim: OBJECT            :commonName
   55:d=5  hl=2 l=   9 prim: UTF8STRING        :Best User
   66:d=3  hl=2 l=  11 cons: SET
   68:d=4  hl=2 l=   9 cons: SEQUENCE
   70:d=5  hl=2 l=   3 prim: OBJECT            :countryName
   75:d=5  hl=2 l=   2 prim: PRINTABLESTRING   :US
   79:d=2  hl=4 l= 290 cons: SEQUENCE
   83:d=3  hl=2 l=  13 cons: SEQUENCE
   85:d=4  hl=2 l=   9 prim: OBJECT            :rsaEncryption
   96:d=4  hl=2 l=   0 prim: NULL
   98:d=3  hl=4 l= 271 prim: BIT STRING
  373:d=2  hl=2 l=   0 cons: cont [ 0 ]
  375:d=1  hl=2 l=  13 cons: SEQUENCE
  377:d=2  hl=2 l=   9 prim: OBJECT            :sha256WithRSAEncryption
  388:d=2  hl=2 l=   0 prim: NULL
  390:d=1  hl=4 l= 257 prim: BIT STRING
```
